### PR TITLE
Feature/UI Schema Support

### DIFF
--- a/packages/ui-schema/src/ObjectRenderer/ObjectRenderer.js
+++ b/packages/ui-schema/src/ObjectRenderer/ObjectRenderer.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {memo} from '@ui-schema/ui-schema/Utils/memo';
-import {PluginStack} from '@ui-schema/ui-schema/PluginStack';
+import { memo } from '@ui-schema/ui-schema/Utils/memo';
+import { PluginStack } from '@ui-schema/ui-schema/PluginStack';
+import { createOrderedMap } from '@ui-schema/ui-schema/Utils/createMap';
 
 const ObjectRendererBase = (
     {
@@ -11,11 +12,11 @@ const ObjectRendererBase = (
         ...props
     },
 ) => {
-    const {isVirtual, widgets} = props
+    const { isVirtual, widgets } = props
     const properties = schema.get('properties');
 
-    if(!isVirtual && !widgets.GroupRenderer) {
-        if(process.env.NODE_ENV === 'development') {
+    if (!isVirtual && !widgets.GroupRenderer) {
+        if (process.env.NODE_ENV === 'development') {
             console.error('Widget GroupRenderer not existing');
         }
         return null;
@@ -27,6 +28,7 @@ const ObjectRendererBase = (
             key={childKey}
             {...props}
             schema={childSchema} parentSchema={schema}
+            uiSchema={schema.get("uiSchema", createOrderedMap()).get(childKey, createOrderedMap()).mergeDeep(childSchema.get("uiSchema", createOrderedMap()))}
             storeKeys={storeKeys.push(childKey)}
             schemaKeys={schemaKeys?.push('properties').push(childKey)}
             level={level + 1}

--- a/packages/ui-schema/src/ObjectRenderer/ObjectRenderer.js
+++ b/packages/ui-schema/src/ObjectRenderer/ObjectRenderer.js
@@ -21,19 +21,19 @@ const ObjectRendererBase = (
         }
         return null;
     }
-    const GroupRenderer = widgets.GroupRenderer;
 
-    const propertyTree = properties?.map((childSchema, childKey) =>
-        <PluginStack
+    const GroupRenderer = widgets.GroupRenderer;
+    const propertyTree = properties?.map((childSchema, childKey) => {
+        return <PluginStack
             key={childKey}
             {...props}
-            schema={childSchema} parentSchema={schema}
-            uiSchema={schema.get("uiSchema", createOrderedMap()).get(childKey, createOrderedMap()).mergeDeep(childSchema.get("uiSchema", createOrderedMap()))}
+            schema={childSchema}
+            parentSchema={schema}
             storeKeys={storeKeys.push(childKey)}
             schemaKeys={schemaKeys?.push('properties').push(childKey)}
             level={level + 1}
-        />,
-    ).valueSeq() || null
+        />
+    },).valueSeq() || null
 
     // no-properties could come from
     //   e.g. combining/conditional schemas which are currently not applied (e.g. a condition fails)

--- a/packages/ui-schema/src/PluginStack/PluginStack.js
+++ b/packages/ui-schema/src/PluginStack/PluginStack.js
@@ -41,8 +41,21 @@ export const PluginStack = ({ StackWrapper, wrapperProps, ...props }) => {
     if (schemaExtract.size > 0) {
         props.schema = props.schema.mergeDeep(schemaExtract);
     }
-    const schema = props.schema
 
+    //Update oneOf uiSchema 
+    if (props.schema.has("oneOf")) {
+        let oneOf = props.schema.get("oneOf");
+        for (let [i, one] of oneOf.entries()) {
+            let _uiSchema = uiSchema.get(one.get("title", null), createOrderedMap()).mergeDeep(one.get("uiSchema", createOrderedMap()));
+            let schemaExtract = checkUISchema(_uiSchema);
+            if (schemaExtract.size > 0) {
+                oneOf = oneOf.set(i, one.mergeDeep(one, schemaExtract));
+            }
+        }
+        props.schema = props.schema.set("oneOf", oneOf);
+    }
+
+    const schema = props.schema
     // central reference integrity of `storeKeys` for all plugins and the receiving widget, otherwise `useImmutable` is needed more times, e.g. 3 times in plugins + 1x time in widget
     const currentStoreKeys = useImmutable(storeKeys)
     const currentSchemaKeys = useImmutable(schemaKeys)

--- a/packages/ui-schema/src/PluginStack/PluginStack.js
+++ b/packages/ui-schema/src/PluginStack/PluginStack.js
@@ -1,26 +1,33 @@
 import React from 'react';
-import {List} from 'immutable';
-import {memo} from '@ui-schema/ui-schema/Utils/memo';
-import {useUIMeta} from '@ui-schema/ui-schema/UIMeta';
-import {createValidatorErrors} from '@ui-schema/ui-schema/ValidatorErrors';
-import {useUIConfig} from '@ui-schema/ui-schema/UIStore';
-import {useImmutable} from '@ui-schema/ui-schema/Utils/useImmutable';
-import {PluginStackErrorBoundary} from '@ui-schema/ui-schema/PluginStack';
+import { List } from 'immutable';
+import { memo } from '@ui-schema/ui-schema/Utils/memo';
+import { useUIMeta } from '@ui-schema/ui-schema/UIMeta';
+import { createValidatorErrors } from '@ui-schema/ui-schema/ValidatorErrors';
+import { useUIConfig } from '@ui-schema/ui-schema/UIStore';
+import { useImmutable } from '@ui-schema/ui-schema/Utils/useImmutable';
+import { PluginStackErrorBoundary } from '@ui-schema/ui-schema/PluginStack';
+import { checkUISchema } from '@ui-schema/ui-schema/UISchema';
 
 const errorContainer = createValidatorErrors()
 
 // `extractValue` has moved to own plugin `ExtractStorePlugin` since `0.3.0`
 // `withUIMeta` and `mema` are not needed for performance optimizing since `0.3.0` at this position
-export const PluginStack = ({StackWrapper, wrapperProps, ...props}) => {
-    const {widgets, ...meta} = useUIMeta()
+export const PluginStack = ({ StackWrapper, wrapperProps, ...props }) => {
+    const { widgets, ...meta } = useUIMeta()
     const config = useUIConfig()
     const {
         level = 0, parentSchema,
         storeKeys = List([]),
         schemaKeys = List([]),
-        schema,
+        uiSchema,
         widgets: customWidgets,
     } = props;
+
+    let schema = props.schema;
+    if (checkUISchema(uiSchema)) {
+        schema = schema.mergeDeep(uiSchema);
+    };
+
     // central reference integrity of `storeKeys` for all plugins and the receiving widget, otherwise `useImmutable` is needed more times, e.g. 3 times in plugins + 1x time in widget
     const currentStoreKeys = useImmutable(storeKeys)
     const currentSchemaKeys = useImmutable(schemaKeys)
@@ -28,11 +35,11 @@ export const PluginStack = ({StackWrapper, wrapperProps, ...props}) => {
 
     const isVirtual = Boolean(props.isVirtual || schema?.get('hidden'))
     let required = List([]);
-    if(parentSchema) {
+    if (parentSchema) {
         // todo: resolving `required` here is wrong, must be done after merging schema / resolving referenced
         //      ! actual, it is correct here, as using `parentSchema`
         let tmp_required = parentSchema.get('required');
-        if(tmp_required) {
+        if (tmp_required) {
             required = tmp_required;
         }
     }
@@ -78,14 +85,14 @@ export const PluginStack = ({StackWrapper, wrapperProps, ...props}) => {
         null
 };
 
-export const getNextPlugin = (next, {pluginStack: ps, WidgetRenderer}) =>
+export const getNextPlugin = (next, { pluginStack: ps, WidgetRenderer }) =>
     next < ps.length ?
         ps[next] || (() => 'plugin-error')
         : WidgetRenderer;
 
-export const NextPluginRenderer = ({currentPluginIndex, ...props}) => {
+export const NextPluginRenderer = ({ currentPluginIndex, ...props }) => {
     const next = currentPluginIndex + 1;
     const Plugin = getNextPlugin(next, props.widgets)
-    return <Plugin {...props} currentPluginIndex={next}/>
+    return <Plugin {...props} currentPluginIndex={next} />
 };
 export const NextPluginRendererMemo = memo(NextPluginRenderer);

--- a/packages/ui-schema/src/PluginStack/PluginStack.js
+++ b/packages/ui-schema/src/PluginStack/PluginStack.js
@@ -24,10 +24,7 @@ export const PluginStack = ({ StackWrapper, wrapperProps, ...props }) => {
     } = props;
 
     //Inherite uiSchema from parent schema element
-    let {
-        uiSchema = createOrderedMap(),
-    } = props.schema;
-
+    let uiSchema = props.schema.get("uiSchema", createOrderedMap());
     if (parentSchema) {
         let _name = storeKeys.last()
         if (typeof _name == "number") {

--- a/packages/ui-schema/src/PluginStack/PluginStack.js
+++ b/packages/ui-schema/src/PluginStack/PluginStack.js
@@ -23,7 +23,7 @@ export const PluginStack = ({ StackWrapper, wrapperProps, ...props }) => {
         widgets: customWidgets,
     } = props;
 
-    //Inherite uiSchema from parent
+    //Inherite uiSchema from parent schema element
     let {
         uiSchema = createOrderedMap(),
     } = props.schema;
@@ -33,7 +33,7 @@ export const PluginStack = ({ StackWrapper, wrapperProps, ...props }) => {
         if (typeof _name == "number") {
             _name = "items"
         }
-        uiSchema = parentSchema.get("uiSchema", createOrderedMap()).get(_name, createOrderedMap()).mergeDeep(uiSchema);
+        uiSchema = uiSchema.mergeDeep(parentSchema.get("uiSchema", createOrderedMap()).get(_name, createOrderedMap()));
     }
     props.schema = props.schema.set("uiSchema", uiSchema);
 
@@ -42,11 +42,11 @@ export const PluginStack = ({ StackWrapper, wrapperProps, ...props }) => {
         props.schema = props.schema.mergeDeep(schemaExtract);
     }
 
-    //Update oneOf uiSchema 
+    //Update oneOf uiSchema with parent uiSchema and apply finally
     if (props.schema.has("oneOf")) {
         let oneOf = props.schema.get("oneOf");
         for (let [i, one] of oneOf.entries()) {
-            let _uiSchema = uiSchema.get(one.get("title", null), createOrderedMap()).mergeDeep(one.get("uiSchema", createOrderedMap()));
+            let _uiSchema = one.get("uiSchema", createOrderedMap()).mergeDeep(uiSchema.get(one.get("title", null), createOrderedMap()));
             let schemaExtract = checkUISchema(_uiSchema);
             if (schemaExtract.size > 0) {
                 oneOf = oneOf.set(i, one.mergeDeep(one, schemaExtract));

--- a/packages/ui-schema/src/UISchema.ts
+++ b/packages/ui-schema/src/UISchema.ts
@@ -1,4 +1,6 @@
 import { tt } from "@ui-schema/ui-schema/Utils"
+import { OrderedMap } from "immutable"
+
 
 export interface UISchema {
     title?: string
@@ -94,4 +96,86 @@ export interface UISchema {
         // to disable am/pm selection
         ampm?: boolean
     }
+}
+
+export function checkUISchema(obj: OrderedMap, uiSchemaProps?: object): boolean {
+    uiSchemaProps = uiSchemaProps || {
+        title: 'string',
+        tt: ['ol', 'upper', 'lower', 'upper-beauty', 'lower-beauty', 'beauty-text', 'beauty-igno-lead', true, false, 0],
+        t: [{}, { '': { '': '' } }],
+        widget: 'string',
+        api: { endpoint: 'string' },
+        hidden: 'boolean',
+        view: {
+            sizeXs: 'number',
+            sizeSm: 'number',
+            sizeMd: 'number',
+            sizeLg: 'number',
+            sizeXl: 'number',
+            noGrid: 'boolean',
+            spacing: 'number',
+            rows: 'number',
+            rowsMax: 'number',
+            variant: 'string',
+            margin: ['none', 'dense', 'normal', 'string'],
+            dense: 'boolean',
+            denseOptions: 'boolean',
+            bg: 'boolean',
+            shrink: 'boolean',
+            formats: ['string'],
+            justify: 'string',
+            marks: [true, false, 'number', 'string'],
+            marksLabel: 'string',
+            tooltip: 'string',
+            topControls: 'boolean',
+            alpha: 'boolean',
+            iconOn: 'boolean',
+            colors: ['string'],
+            btnSize: ['normal', 'medium', 'small'],
+            track: [true, false, 'inverted'],
+            mt: 'number',
+            mb: 'number',
+        },
+        date: {
+            format: 'string',
+            formatData: 'string',
+            keyboard: 'boolean',
+            views: [['year', 'date', 'month', 'hours', 'minutes']],
+            variant: 'string',
+            autoOk: 'boolean',
+            disableFuture: 'boolean',
+            disablePast: 'boolean',
+            toolbar: 'boolean',
+            clearable: 'boolean',
+            minDate: 'string',
+            maxDate: 'string',
+            openTo: ['year', 'date', 'month'],
+            orientation: ['landscape', 'portrait'],
+            tabs: 'boolean',
+            minutesStep: 'number',
+            ampm: 'boolean',
+        },
+    };
+
+    if (obj == undefined) {
+        return false;
+    }
+
+    for (let prop in uiSchemaProps) {
+        const expectedType = uiSchemaProps[prop];
+        const actualType = typeof obj.get(prop);
+        if (
+            typeof expectedType == "object" && obj.has(prop)
+        ) {
+            return checkUISchema(obj.get(prop), expectedType)
+        }
+        else if (
+            obj.has(prop) &&
+            ((Array.isArray(expectedType) && expectedType.indexOf(typeof obj.get(prop)) == -1) ||
+                (!Array.isArray(expectedType) && actualType !== expectedType))
+        ) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/packages/ui-schema/src/UISchema.ts
+++ b/packages/ui-schema/src/UISchema.ts
@@ -98,7 +98,7 @@ export interface UISchema {
     }
 }
 
-export function checkUISchema(obj: OrderedMap, uiSchemaProps?: object): boolean {
+export function checkUISchema(obj: OrderedMap, uiSchemaProps?: object): OrderedMap {
     uiSchemaProps = uiSchemaProps || {
         title: 'string',
         tt: ['ol', 'upper', 'lower', 'upper-beauty', 'lower-beauty', 'beauty-text', 'beauty-igno-lead', true, false, 0],
@@ -158,24 +158,19 @@ export function checkUISchema(obj: OrderedMap, uiSchemaProps?: object): boolean 
     };
 
     if (obj == undefined) {
-        return false;
+        return OrderedMap({});
     }
-
+    let props = {};
     for (let prop in uiSchemaProps) {
         const expectedType = uiSchemaProps[prop];
         const actualType = typeof obj.get(prop);
-        if (
-            typeof expectedType == "object" && obj.has(prop)
-        ) {
-            return checkUISchema(obj.get(prop), expectedType)
-        }
-        else if (
-            obj.has(prop) &&
-            ((Array.isArray(expectedType) && expectedType.indexOf(typeof obj.get(prop)) == -1) ||
-                (!Array.isArray(expectedType) && actualType !== expectedType))
-        ) {
-            return false;
+        if (typeof expectedType == "object" && obj.has(prop)) {
+            props[prop] = checkUISchema(obj.get(prop), expectedType);
+        } else if (!(obj.has(prop) && (Array.isArray(expectedType) && expectedType.indexOf(typeof obj.get(prop)) == -1 || !Array.isArray(expectedType) && actualType !== expectedType))) {
+            if (obj.has(prop)) {
+                props[prop] = obj.get(prop);
+            }
         }
     }
-    return true;
+    return OrderedMap(props);
 }

--- a/packages/ui-schema/src/UISchema.ts
+++ b/packages/ui-schema/src/UISchema.ts
@@ -96,6 +96,7 @@ export interface UISchema {
         // to disable am/pm selection
         ampm?: boolean
     }
+    uiSchema?: object
 }
 
 export function checkUISchema(obj: OrderedMap, uiSchemaProps?: object): OrderedMap {

--- a/packages/ui-schema/tests/UIRenderer.test.tsx
+++ b/packages/ui-schema/tests/UIRenderer.test.tsx
@@ -34,17 +34,17 @@ import { relTranslator } from '@ui-schema/ui-schema/Translate/relT'
  * npm test -- --testPathPattern=UIRenderer.test.tsx -u
  */
 
-expect.extend({toBeInTheDocument, toHaveClass})
+expect.extend({ toBeInTheDocument, toHaveClass })
 const widgets = MockWidgets
 // todo: add custom ErrorFallback, otherwise some errors may be catched there - and the test will not fail
 
 // eslint-disable-next-line react/display-name,deprecation/deprecation
 widgets.RootRenderer = (props: PropsWithChildren<any>): React.ReactElement => <div className={'root-renderer'}>{props.children}</div>
 // eslint-disable-next-line react/display-name
-widgets.GroupRenderer = ({children}): React.ReactElement => <div className={'group-renderer'}>{children}</div>
+widgets.GroupRenderer = ({ children }): React.ReactElement => <div className={'group-renderer'}>{children}</div>
 widgets.pluginStack = [
     // plugin to have every widget in it's own div - to query against in tests
-    (props) => <div><NextPluginRenderer {...props}/></div>,
+    (props) => <div><NextPluginRenderer {...props} /></div>,
     ReferencingHandler,
     ExtractStorePlugin,
     CombiningHandler,
@@ -60,7 +60,7 @@ widgets.pluginSimpleStack = validators
 widgets.types.string = (props: WidgetProps): React.ReactElement => {
     return <>
         <span>string-renderer</span>
-        <span><TransTitle schema={props.schema} storeKeys={props.storeKeys}/></span>
+        <span><TransTitle schema={props.schema} storeKeys={props.storeKeys} /></span>
         {props.valid ? null : <span>string-with-error</span>}
         {props.errors.hasError() ? <span>{JSON.stringify(props.errors.errorsToJS())}</span> : null}
     </>
@@ -70,11 +70,11 @@ widgets.types.string = (props: WidgetProps): React.ReactElement => {
 widgets.types.array = extractValue((props: WidgetProps & WithValue): React.ReactElement => {
     return <>
         <span>array-renderer</span>
-        <span><TransTitle schema={props.schema} storeKeys={props.storeKeys}/></span>
+        <span><TransTitle schema={props.schema} storeKeys={props.storeKeys} /></span>
         {/* @ts-ignore */}
         {List.isList(props.value) ? props.value.map((val, i: number) =>
             <div key={i}>
-                <div style={{display: 'flex', flexDirection: 'column', flexGrow: 2}}>
+                <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 2 }}>
                     {null}
                     {/* @ts-ignore */}
                     <PluginStack
@@ -101,7 +101,7 @@ const TestUIRenderer = (props: {
 }) => {
 
     // needed variables and setters for the UIGenerator, create wherever you like
-    const [store, setStore] = React.useState(() => createStore(createOrderedMap(props.data || {demo_string: ''})))
+    const [store, setStore] = React.useState(() => createStore(createOrderedMap(props.data || { demo_string: '' })))
 
     const [schema/*, setSchema*/] = React.useState(() => createOrderedMap({
         type: 'object',
@@ -124,7 +124,7 @@ const TestUIRenderer = (props: {
                     } as JsonSchema,
                     children: {
                         type: 'array',
-                        items: {$ref: '#/definitions/person'},
+                        items: { $ref: '#/definitions/person' },
                         'default': [],
                     },
                 },
@@ -167,7 +167,14 @@ const TestUIRenderer = (props: {
                     type: 'string',
                 },
             },
-            person: {$ref: '#/definitions/person'},
+            person: { $ref: '#/definitions/person' },
+            uiSchema: {
+                person: {
+                    name: {
+                        title: "Person Name"
+                    }
+                }
+            }
         },
         allOf: [{
             if: {
@@ -223,9 +230,9 @@ const TestUIRenderer = (props: {
 }
 
 describe('UIGenerator Integration', () => {
-    it('TestUIRenderer', async() => {
-        const {queryByText, queryAllByText, container} = render(
-            <TestUIRenderer data={{demo_number: 10, demo_array2: ['val-test']}}/>
+    it('TestUIRenderer', async () => {
+        const { queryByText, queryAllByText, container } = render(
+            <TestUIRenderer data={{ demo_number: 10, demo_array2: ['val-test'] }} />
         )
         // expect(container).toMatchSnapshot()
         expect(container.querySelectorAll('.root-renderer').length).toBe(1)
@@ -238,9 +245,9 @@ describe('UIGenerator Integration', () => {
         expect(queryByText('missing-type-number') !== null).toBeTruthy()
         expect(queryAllByText('array-renderer').length).toBe(3)
     })
-    it('TestUIRenderer no `store`', async() => {
-        const {queryByText, queryAllByText, container} = render(
-            <TestUIRenderer noStore/>
+    it('TestUIRenderer no `store`', async () => {
+        const { queryByText, queryAllByText, container } = render(
+            <TestUIRenderer noStore />
         )
         // expect(container).toMatchSnapshot()
         expect(container.querySelectorAll('.root-renderer').length).toBe(1)
@@ -251,9 +258,9 @@ describe('UIGenerator Integration', () => {
         expect(queryAllByText('string-renderer').length).toBe(2)
         expect(queryByText('store-is-invalid') !== null).toBeTruthy()
     })
-    it('TestUIRenderer not `t`', async() => {
-        const {queryByText, queryAllByText, container} = render(
-            <TestUIRenderer notT/>
+    it('TestUIRenderer not `t`', async () => {
+        const { queryByText, queryAllByText, container } = render(
+            <TestUIRenderer notT />
         )
         expect(container.querySelectorAll('.root-renderer').length).toBe(1)
         expect(container.querySelectorAll('.group-renderer').length).toBe(2)
@@ -261,9 +268,9 @@ describe('UIGenerator Integration', () => {
         expect(queryByText('widget.demo_string.title')).toBe(null)
         expect(queryAllByText('string-renderer').length).toBe(3)
     })
-    it('TestUIRenderer ConditionalCombining', async() => {
-        const {queryByText, container} = render(
-            <TestUIRenderer data={{demo_string: 'test'}}/>
+    it('TestUIRenderer ConditionalCombining', async () => {
+        const { queryByText, container } = render(
+            <TestUIRenderer data={{ demo_string: 'test' }} />
         )
         // expect(container).toMatchSnapshot()
         expect(container.querySelectorAll('.root-renderer').length === 1).toBeTruthy()
@@ -271,13 +278,13 @@ describe('UIGenerator Integration', () => {
         expect(queryByText('widget.demo_string.title') === null).toBeTruthy()
         expect(queryByText('missing-custom-Text') !== null).toBeTruthy()
     })
-    it('TestUIRendererError', async() => {
-        const {queryByText, queryAllByText, container} = render(
+    it('TestUIRendererError', async () => {
+        const { queryByText, queryAllByText, container } = render(
             <TestUIRenderer data={{
                 demo_string: 'to-long-text', demo_number: 83,
                 // @ts-ignore
                 demo_array: 'not-an-array',
-            }}/>
+            }} />
         )
         //expect(container).toMatchSnapshot()
         expect(container.querySelectorAll('.root-renderer').length === 1).toBeTruthy()
@@ -288,5 +295,6 @@ describe('UIGenerator Integration', () => {
         expect(queryByText('string-with-error') !== null).toBeTruthy()
         expect(queryAllByText('string-renderer').length === 2).toBeTruthy()
     })
+    //ToDO add uiSchema test
 })
 


### PR DESCRIPTION
Big schemas (e.g. openApi) often consists of the same components intending to establish modularity inside the schema description. Often styling & titles varies depending on the target where the components are integrated. 

Currently ui-schema doesn't provide a solution to inherite styling components from their base description to the child components. With this request a new property "uiSchema" is introduced which exactly provides a solution for this case. E.g. a schema like the following one allows different titles with the same child components from the definitions block :

```json
{
  "definitions": {
    "User": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string",
          "default": ""
        },
        "age": {
          "type": "integer",
          "default": 0
        },
        "meta": {
          "type": "string",
          "default": ""
        }
      }
    }
  },
  "title": "Config",
  "required": [
    "personal_user_info",
    "third_party_user_info"
  ],
  "type": "object",
  "properties": {
    "personal_user_info": {
      "$ref": "#/definitions/User"
    },
    "third_party_user_info": {
      "$ref": "#/definitions/User"
    }
  },
  "uiSchema": {
    "personal_user_info": {
      "meta": {
        "title": "Personal Preferences",
        "sizeMd": 12
      }
    },
    "third_party_user_info": {
      "meta": {
        "title": "External Preferences",
        "sizeMd": 8
      }
    }
  }
}
```

Finally the feature adds more flexible stylings, while keeping modularities.
