### PR TITLE
WIP: expose error-types to store...

### DIFF
--- a/packages/ui-schema/src/ValidityReporter/ValidityReporter.js
+++ b/packages/ui-schema/src/ValidityReporter/ValidityReporter.js
@@ -18,10 +18,10 @@ export const ValidityReporter = (props) => {
             storeKeys: storeKeysRef,
             scopes: ['valid'],
             data: {
-                valid: realValid,
+                valid: props.errors.get('errors'),
             },
         })
-    }, [realValid, onChange, storeKeysRef]);
+    }, [realValid, onChange, storeKeysRef, customError]);
 
     React.useEffect(() => {
         // delete own validity state on component unmount

--- a/packages/ui-schema/src/storeScopeUpdater/scopeUpdaterValidity.ts
+++ b/packages/ui-schema/src/storeScopeUpdater/scopeUpdaterValidity.ts
@@ -1,5 +1,5 @@
 import { prependKey } from '@ui-schema/ui-schema/UIStore'
-import { List } from 'immutable'
+import { List, isMap } from 'immutable'
 import { ScopeOnChangeHandler } from '@ui-schema/ui-schema/storeUpdater'
 import { updateStoreScope } from '@ui-schema/ui-schema/storeScopeUpdater'
 
@@ -10,10 +10,23 @@ export const scopeUpdaterValidity: ScopeOnChangeHandler = (store, storeKeys, new
     storeKeys = storeKeys.map(k => k?.toString()) as List<string>
     if (typeof newValue === 'undefined') {
         store = store.deleteIn(prependKey(storeKeys.push('__valid'), 'validity'))
+        store = store.deleteIn(prependKey(storeKeys.push('__errors'), 'validity'))
+        store = store.deleteIn(prependKey(storeKeys.push('__errCount'), 'validity'))
     } else {
+        if (!isMap(newValue)) return store
+
+        const errCount = newValue.size
         store = updateStoreScope(
             store, 'validity', storeKeys.push('__valid'),
-            newValue
+            errCount > 0 ? false : true
+        )
+        store = updateStoreScope(
+            store, 'validity', storeKeys.push('__errors'),
+            [...newValue.keys()]
+        )
+        store = updateStoreScope(
+            store, 'validity', storeKeys.push('__errCount'),
+            errCount
         )
     }
     return store


### PR DESCRIPTION
What I'm hoping for with this PR is to expose the error-types set by `addError` to be exposed to the store that way we can do something like:

```ts
if (store.getValidity(ERROR_NOT_SET).size > 0) {
  alert("You have missing properties, do you want to save anyways?")
}
```

The result I currently get with this code in the demo is
<img width="374" alt="image" src="https://github.com/ui-schema/ui-schema/assets/16711653/fbad3793-bf29-4bf0-a67d-8d6fb10af982">
